### PR TITLE
Define request urls as constants

### DIFF
--- a/src/api/auth.tsx
+++ b/src/api/auth.tsx
@@ -11,7 +11,11 @@ export const performLogin = async (
   }
 
   try {
-    const response = await api.post("auth/login/", {}, {
+    const url = `${API_BASE_URL}auth/login/`;
+    const response = await axios.post(
+      url,
+      {},
+      {
         auth: {
           username: email,
           password: password,

--- a/src/api/partnerLocation.tsx
+++ b/src/api/partnerLocation.tsx
@@ -2,7 +2,8 @@ import { api } from "./config";
 
 export const getPartnerLocations = async () => {
   try {
-    const response = await api.get("partner_location/");
+    const url = `${API_BASE_URL}partner_location/`;
+    const response = await axios.get(url);
 
     // Async Storage
 


### PR DESCRIPTION
I have no clue why that is necessary for the api to work, but it is.